### PR TITLE
CSM-6801: Added sqs GetQueueURL for auto-integration

### DIFF
--- a/lambdas/constants.js
+++ b/lambdas/constants.js
@@ -54,6 +54,7 @@ const ReadOnlyPolicy = `{
               "sns:GetTopicAttributes",
               "sns:ListTopics",
               "sns:GetSubscriptionAttributes",
+              "sqs:GetQueueUrl",
               "sqs:ListQueues",
               "sqs:GetQueueAttributes",
               "sqs:ListQueueTags",


### PR DESCRIPTION
We need this for grabbing the the queueUrl in the CMC.  