### PR TITLE
Adding permission for SearchTransitGatewayRoutes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ resource "aws_iam_role" "role" {
             "ds:ListTagsForResource",
             "ec2:DescribeAccountAttributes",
             "ec2:GetEbsEncryptionByDefault",
+            "ec2:SearchTransitGatewayRoutes",
             "eks:DescribeAddon",
             "eks:DescribeCluster",
             "eks:DescribeFargateProfile",


### PR DESCRIPTION
Task Based on - https://uptycsjira.atlassian.net/browse/CSM-6950

Adding read permission for aws-`ec2 : SearchTransitGatewayRoutes`. Required for table: `"aws_ec2_transit_gw_routes"`