### PR TITLE
AWS org terraform : source code is pointing to github instead of terraform registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ export AWS_DEFAULT_REGION="< pass region >"
 
 ```
 module "org-config" {
-  source           = "github.com/uptycslabs/terraform-aws-org-integration"
+  source           = "uptycslabs/org-integration/aws"
 
   # Modify as you need, this will be used to name the resources
   integration_name = "UptycsIntegration"


### PR DESCRIPTION
- changed the source from git repository to terraform registry

**Test Cases:**

- [x] Run terraform with source as git repository and then change the source to  terraform registry no changes should happen
- [x] Destroy earlier terraform re-run with source as  terraform registry. It should not fail
- [x] Integrate org both the times it should not fail