### PR TITLE
CSM-7044: Backend Support: Edit child accounts of an Org

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ output "aws_parameters" {
 
 
 | Name                           | Description                                                            | Type     | Default             | Required |
-| :------------------------------- | ------------------------------------------------------------------------ | ---------- | --------------------- | ---------- |
+| ------------------------------- | ------------------------------------------------------------------------ | ---------- | --------------------- | ---------- |
 | integration_name               | Prefix to be used for naming new resources                             | `string` | `UptycsIntegration` |          |
 | upt_account_id                 | Uptycs AWS account ID                                                  | `string` | `""`                | Yes      |
 | aws_account_id                 | AWS organization's master account ID                                   | `string` | `""`                | Yes      |

--- a/README.md
+++ b/README.md
@@ -74,8 +74,13 @@ module "org-config" {
   cloudtrail_s3_bucket_in_master = true
 
   # Provide the S3 bucket name which contains the CloudTrail data
-  # Ignore this field in case the CloudTrail S3 bucket is in a child account
   cloudtrail_s3_bucket_name = ""
+
+ # Provide the accountId where the cloudrail bucket exists
+ # Provide the S3 bucket's region
+ # Ignore If cloudtrail bucket is in master account
+ cloudtrail_s3_bucket_account = ""
+ cloudtrail_s3_bucket_region = ""
 
   # Name of the Kinesis stream configured to stream CloudTrail data
   kinesis_stream_name = ""
@@ -95,15 +100,17 @@ output "aws_parameters" {
 
 
 | Name                           | Description                                                            | Type     | Default             | Required |
-| -------------------------------- | ------------------------------------------------------------------------ | ---------- | --------------------- | ---------- |
+| :------------------------------- | ------------------------------------------------------------------------ | ---------- | --------------------- | ---------- |
 | integration_name               | Prefix to be used for naming new resources                             | `string` | `UptycsIntegration` |          |
 | upt_account_id                 | Uptycs AWS account ID                                                  | `string` | `""`                | Yes      |
 | aws_account_id                 | AWS organization's master account ID                                   | `string` | `""`                | Yes      |
 | external_id                    | External ID                                                            | `uuid4`  | `""`                | Yes      |
 | vpc_flowlogs_bucket_name       | Name of the S3 bucket in master for VPC flow logs                      | `string` | `""`                | Optional |
-| cloudtrail_s3_bucket_name      | Name of the organization cloud trail S3 bucket                         | `string` | `""`                | Optional |
+| cloudtrail_s3_bucket_name      | Name of the organization's cloud trail S3 bucket                       | `string` | `""`                | Optional |
 | cloudtrail_s3_bucket_in_master | Specifies whether the cloudtrail s3 bucket is in master account or not | `bool`   | `true`              |          |
-| kinesis_stream_name            | Name of the organization Kinesis stream                                | `string` | `""`                | Optional |
+| cloudtrail_s3_bucket_account   | Child Account id in which the cloudtrail S3 bucket exists              | `string` | `""`                | Optional |
+| cloudtrail_s3_bucket_region    | Region where CloudTrail bucket exists                                  | `string` | `""`                | Optional |
+| kinesis_stream_name            | Name of the organization's Kinesis stream                                | `string` | `""`                | Optional |
 
 ### Execute Terraform script
 

--- a/uptycscspm.tf
+++ b/uptycscspm.tf
@@ -2,8 +2,14 @@
 data "aws_organizations_organization" "my_org" {
 }
 
+data "aws_organizations_resource_tags" "cloudtrail_account" {
+  count       = (!var.cloudtrail_s3_bucket_in_master && var.cloudtrail_s3_bucket_name != "") ? 1 : 0
+  resource_id = var.cloudtrail_s3_bucket_account
+}
+
 locals {
   child_accounts_active = var.defer_role_creation ? [] : toset([for each in data.aws_organizations_organization.my_org.non_master_accounts : each.id if each.status == "ACTIVE"])
+  cloudtrail_account    = (!var.cloudtrail_s3_bucket_in_master && var.cloudtrail_s3_bucket_name != "") ? data.aws_organizations_resource_tags.cloudtrail_account[0].id : ""
 }
 
 resource "uptycscspm_role" "child_account_role" {
@@ -14,8 +20,8 @@ resource "uptycscspm_role" "child_account_role" {
   external_id      = var.external_id
   profile_name     = data.external.env.result["aws_profile"]
   policy_document  = local.child_policy_document
-  bucket_name      = (!var.cloudtrail_s3_bucket_in_master && each.key == var.cloudtrail_s3_bucket_account) ? var.cloudtrail_s3_bucket_name : ""
-  bucket_region    = (!var.cloudtrail_s3_bucket_in_master && each.key == var.cloudtrail_s3_bucket_account) ? var.cloudtrail_s3_bucket_region : ""
+  bucket_name      = (!var.cloudtrail_s3_bucket_in_master && each.key == local.cloudtrail_account) ? var.cloudtrail_s3_bucket_name : ""
+  bucket_region    = (!var.cloudtrail_s3_bucket_in_master && each.key == local.cloudtrail_account) ? var.cloudtrail_s3_bucket_region : ""
 
   lifecycle {
     replace_triggered_by = [

--- a/uptycscspm.tf
+++ b/uptycscspm.tf
@@ -13,6 +13,9 @@ resource "uptycscspm_role" "child_account_role" {
   upt_account_id   = var.upt_account_id
   external_id      = var.external_id
   profile_name     = data.external.env.result["aws_profile"]
+  policy_document  = local.child_policy_document
+  bucket_name      = (!var.cloudtrail_s3_bucket_in_master && each.key == var.cloudtrail_s3_bucket_account) ? var.cloudtrail_s3_bucket_name : ""
+  bucket_region    = (!var.cloudtrail_s3_bucket_in_master && each.key == var.cloudtrail_s3_bucket_account) ? var.cloudtrail_s3_bucket_region : ""
 
   lifecycle {
     replace_triggered_by = [

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,18 @@ variable "cloudtrail_s3_bucket_name" {
   default     = ""
 }
 
+variable "cloudtrail_s3_bucket_region" {
+  type        = string
+  description = "Region where CloudTrail bucket exists"
+  default     = ""
+}
+
+variable "cloudtrail_s3_bucket_account" {
+  type        = string
+  description = "Child Account id in which the cloudtrail S3 bucket exists"
+  default     = ""
+}
+
 variable "cloudtrail_s3_bucket_in_master" {
   description = "Specifies whether cloudtrail s3 bucket is in master account or not"
   type        = string


### PR DESCRIPTION
Added support of cloudtrail in child accounts when auto integration is disbaled

TestCases:
- [ ] cloudtrail is in master
- [ ] cloudtrail bucket is in child account
- [ ]  change cloudtrail from [child1, bucket1] to [child1, bucket2]
- [ ]  change from [child1, bucket1] to [child2, bucket2]
- [ ] change [child1, bucket1] to null
- [ ] change inline policy document and role should be updated